### PR TITLE
Error status should deserialise as a string.

### DIFF
--- a/error.go
+++ b/error.go
@@ -32,7 +32,7 @@ http://jsonapi.org/format/#error-objects
 type Error struct {
 	Title  string `json:"title"`
 	Detail string `json:"detail"`
-	Status int    `json:"status"`
+	Status int    `json:"status,string"`
 	Source struct {
 		Pointer string `json:"pointer"`
 	} `json:"source"`


### PR DESCRIPTION
See http://jsonapi.org/format/#error-objects.
