### PR TITLE
Removes alpha validation on object type.

### DIFF
--- a/object.go
+++ b/object.go
@@ -10,7 +10,7 @@ import (
 
 // Object represents the default JSON spec for objects
 type Object struct {
-	Type          string             `json:"type" valid:"alpha,required"`
+	Type          string             `json:"type" valid:"required"`
 	ID            string             `json:"id"`
 	Attributes    json.RawMessage    `json:"attributes,omitempty"`
 	Links         map[string]*Link   `json:"links,omitempty"`


### PR DESCRIPTION
The alpha validation provided by govalidator prevents underscores and other characters that are normally used to split up multi word types. (e.g multi_word_type)

This PR removes the alpha validation.
