### PR TITLE
Fix a logic error in validation of responses with both data and included

### DIFF
--- a/document.go
+++ b/document.go
@@ -95,7 +95,7 @@ func (d *Document) Validate(r *http.Request, response bool) *Error {
 	if d.HasErrors() && d.HasData() {
 		return ISE("Both `errors` and `data` cannot be set for a JSON response")
 	}
-	if d.HasData() && d.Included != nil {
+	if !d.HasData() && d.Included != nil {
 		return ISE("'included' should only be set for a response if 'data' is as well")
 	}
 

--- a/document_test.go
+++ b/document_test.go
@@ -71,12 +71,43 @@ func TestDocument(t *testing.T) {
 				Status: http.StatusAccepted,
 			}
 
+			testObjectForInclusion := &Object{
+				ID: "1",
+				Type: "Included",
+			}
+
+			req := &http.Request{Method: "GET"}
+
 			Convey("should accept an object", func() {
 				doc := Build(testObject)
 
 				So(doc.Data, ShouldResemble, List{testObject})
 				So(doc.Status, ShouldEqual, http.StatusAccepted)
 			})
+
+			Convey("should not accept an included object without objects in data", func() {
+				doc := New()
+				doc.Included = append(doc.Included, testObjectForInclusion)
+				doc.Status = 200
+
+				validationErrors := doc.Validate(req, true)
+
+				So(validationErrors, ShouldNotBeNil)
+			})
+
+			Convey("should not accept  an object in data and an included object", func() {
+				doc := Build(testObject)
+				doc.Included = append(doc.Included, testObjectForInclusion)
+
+				validationErrors := doc.Validate(req, true)
+
+				So(validationErrors, ShouldBeNil)
+				So(doc.Data, ShouldResemble, List{testObject})
+				So(doc.Included, ShouldNotBeEmpty)
+				So(doc.Included[0], ShouldResemble, testObjectForInclusion)
+				So(doc.Status, ShouldEqual, http.StatusAccepted)
+			})
+
 
 			Convey("should accept a list", func() {
 				list := List{testObject}

--- a/document_test.go
+++ b/document_test.go
@@ -95,7 +95,7 @@ func TestDocument(t *testing.T) {
 				So(validationErrors, ShouldNotBeNil)
 			})
 
-			Convey("should not accept  an object in data and an included object", func() {
+			Convey("should accept an object in data and an included object", func() {
 				doc := Build(testObject)
 				doc.Included = append(doc.Included, testObjectForInclusion)
 


### PR DESCRIPTION
I noticed that after updating the library, my application does not behave well with objects added to "included" section in a document. When debugging, I spotted a validity test that seems to contradict the spec and also the error message returned for the same validation test.

The upstream Document::Validate is, according to the error message, expected to return an ISE if "included" has values when "data" has none. However, the logic in the upstream tries a different case: it considers having both "included" and "data" an error.

I added a negation to the implementation, and it now the validation test seems to match its error message.. Also, I updated test cases so that they cover validation a bit more. I have previously not used goconvoy, but I hope the tests are OK.
