### PR TITLE
Fix #20 List containing a single object not marshaled as an array

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -118,7 +118,7 @@ func testAPI() *jshapi.API {
 		return object, nil
 	})
 
-	api := jshapi.New("", true)
+	api := jshapi.New("")
 	api.Add(resource)
 
 	return api

--- a/list.go
+++ b/list.go
@@ -52,8 +52,7 @@ func (list *List) UnmarshalJSON(rawData []byte) error {
 }
 
 /*
-MarshalJSON returns a top level object for the "data" attribute if a single object. In
-all other cases returns a JSON encoded list for "data". We use a pointer receiver here
+MarshalJSON returns a JSON encoded list for "data". We use a pointer receiver here
 so we are able to distinguish between nil (don't serialize) and empty (serialize as []).
 */
 func (list *List) MarshalJSON() ([]byte, error) {
@@ -70,8 +69,6 @@ func (list *List) MarshalJSON() ([]byte, error) {
 	switch {
 	case count == 0:
 		return []byte("[]"), nil
-	case count == 1:
-		return json.Marshal(marshalList[0])
 	default:
 		return json.Marshal(marshalList)
 	}


### PR DESCRIPTION
@derekdowling This does not address the unmarshal/parse side of the issue, but personally I'm okay with being more lenient there. If we must detect whether we received an array or object, we would need to move the logic from https://github.com/derekdowling/go-json-spec-handler/blob/master/list.go#L37 into the `Parser` 
