### PR TITLE
Fixed link compatibility with the specification

### DIFF
--- a/document.go
+++ b/document.go
@@ -29,7 +29,7 @@ type Document struct {
 	Data List `json:"data"`
 	// Object   *Object     `json:"-"`
 	Errors   ErrorList   `json:"errors,omitempty"`
-	Links    *Link       `json:"links,omitempty"`
+	Links    *Links      `json:"links,omitempty"`
 	Included []*Object   `json:"included,omitempty"`
 	Meta     interface{} `json:"meta,omitempty"`
 	JSONAPI  struct {

--- a/link.go
+++ b/link.go
@@ -1,5 +1,10 @@
 package jsh
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // Links is a top-level document field
 type Links struct {
 	Self    *Link `json:"self,omitempty"`
@@ -10,4 +15,21 @@ type Links struct {
 type Link struct {
 	HREF string                 `json:"href,omitempty"`
 	Meta map[string]interface{} `json:"meta,omitempty"`
+}
+
+func (link *Link) UnmarshalJSON(data []byte) error {
+	var v interface{}
+	err := json.Unmarshal(data, &v)
+	if err != nil {
+		return err
+	}
+	switch vv := v.(type) {
+	case string:
+		link.HREF = vv
+	case Link:
+		*link = vv
+	default:
+		return fmt.Errorf("unknown Link type (got %v)", vv)
+	}
+	return nil
 }


### PR DESCRIPTION
Links that are simply strings were causing parsing errors in the
JSON deserialization. This is allowed in JSON:API v1.

The top-level links object in Document was of the wrong type. It
should be `*Links` not `*Link`.
