### PR TITLE
Update content type header checking

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -160,7 +160,7 @@ func closeReader(reader io.ReadCloser) {
 func validateHeaders(headers http.Header) *Error {
 
 	reqContentType := headers.Get("Content-Type")
-	if reqContentType != ContentType {
+	if strings.Contains(reqContentType, ContentType) == false {
 		return SpecificationError(fmt.Sprintf(
 			"Expected Content-Type header to be %s, got: %s",
 			ContentType,

--- a/parser.go
+++ b/parser.go
@@ -159,7 +159,6 @@ func closeReader(reader io.ReadCloser) {
 }
 
 func validateHeaders(headers http.Header) *Error {
-
 	reqContentType := headers.Get("Content-Type")
 	if strings.Contains(reqContentType, ContentType) == false {
 		return SpecificationError(fmt.Sprintf(

--- a/parser.go
+++ b/parser.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strings"
 )
 
 /*

--- a/parser_test.go
+++ b/parser_test.go
@@ -129,3 +129,27 @@ func TestParsing(t *testing.T) {
 		})
 	})
 }
+
+func TestContentType(t *testing.T) {
+	Convey("Parse Tests", t, func() {
+		Convey("should contain json api content type", func() {
+			Convey("->validateHeaders()", func() {
+				// Set up request
+				req, reqErr := http.NewRequest("GET", "", nil)
+				So(reqErr, ShouldBeNil)
+				req.Header.Set("Content-Type", ContentType)
+
+				// Contains the default content type
+				err := validateHeaders(req.Header)
+				So(err, ShouldBeNil)
+				So(req.Header.Get("Content-Type"), ShouldContainSubstring, ContentType)
+
+				// Contains the default content type and charset
+				req.Header.Set("Content-Type", ContentType+"; charset=utf-8")
+				err = validateHeaders(req.Header)
+				So(err, ShouldBeNil)
+				So(req.Header.Get("Content-Type"), ShouldContainSubstring, ContentType)
+			})
+		})
+	})
+}


### PR DESCRIPTION
The verification of the content type now checks if the request content type if contained and not if it's equal.
This allows the have content types such as "application/vnd.api+json; charset=utf-8"